### PR TITLE
Improves 'Add device' error message.

### DIFF
--- a/internal/devices/devices.go
+++ b/internal/devices/devices.go
@@ -79,7 +79,7 @@ func (d *DeviceManager) StartSync(disableMetadataCollection, disableInactiveDevi
 
 func (d *DeviceManager) AddDevice(identity *authsession.Identity, name string, publicKey string, presharedKey string) (*storage.Device, error) {
 	if name == "" {
-		return nil, errors.New("device name must not be empty")
+		return nil, errors.New("Device name must not be empty.")
 	}
 
 	var nameTaken bool = false
@@ -92,21 +92,21 @@ func (d *DeviceManager) AddDevice(identity *authsession.Identity, name string, p
 	}
 
 	if nameTaken {
-		return nil, errors.New("device name already taken")
+		return nil, errors.New("Device name already taken.")
 	}
 
 	if !wgKeyRegex.MatchString(publicKey) {
-		return nil, errors.New("public key has invalid format")
+		return nil, errors.New("Public key has invalid format.")
 	}
 
 	// preshared key is optional
 	if len(presharedKey) != 0 && !wgKeyRegex.MatchString(presharedKey) {
-		return nil, errors.New("pre-shared key has invalid format")
+		return nil, errors.New("Pre-shared key has invalid format.")
 	}
 
 	clientAddr, err := d.nextClientAddress()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to generate an ip address for device")
+		return nil, errors.Wrap(err, "Failed to generate an ip address for device")
 	}
 
 	device := &storage.Device{
@@ -173,7 +173,7 @@ func (d *DeviceManager) ListDevices(user string) ([]*storage.Device, error) {
 func (d *DeviceManager) DeleteDevice(user string, name string) error {
 	device, err := d.storage.Get(user, name)
 	if err != nil {
-		return errors.Wrap(err, "failed to retrieve device")
+		return errors.Wrap(err, "Failed to retrieve device")
 	}
 
 	if err := d.storage.Delete(device); err != nil {
@@ -195,7 +195,7 @@ func (d *DeviceManager) nextClientAddress() (string, error) {
 
 	devices, err := d.ListDevices("")
 	if err != nil {
-		return "", errors.Wrap(err, "failed to list devices")
+		return "", errors.Wrap(err, "Failed to list devices")
 	}
 
 	// TODO: read up on better ways to allocate client's IP
@@ -256,18 +256,18 @@ func (d *DeviceManager) nextClientAddress() (string, error) {
 		if ipv6 != "" {
 			return fmt.Sprintf("%s, %s", ipv4, ipv6), nil
 		} else if d.cidrv6 != "" {
-			return "", fmt.Errorf("there are no free IP addresses in the vpn subnet: '%s'", d.cidrv6)
+			return "", fmt.Errorf("There are no free IP addresses in the vpn subnet: '%s'", d.cidrv6)
 		} else {
 			return ipv4, nil
 		}
 	} else if ipv6 != "" {
 		if d.cidr != "" {
-			return "", fmt.Errorf("there are no free IP addresses in the vpn subnet: '%s'", d.cidr)
+			return "", fmt.Errorf("There are no free IP addresses in the vpn subnet: '%s'", d.cidr)
 		} else {
 			return ipv6, nil
 		}
 	} else {
-		return "", fmt.Errorf("there are no free IP addresses in the vpn subnets: '%s', '%s'", d.cidr, d.cidrv6)
+		return "", fmt.Errorf("There are no free IP addresses in the vpn subnets: '%s', '%s'", d.cidr, d.cidrv6)
 	}
 }
 

--- a/website/src/components/AddDevice.tsx
+++ b/website/src/components/AddDevice.tsx
@@ -29,6 +29,7 @@ import AccordionSummary from '@mui/material/AccordionSummary';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import Box from '@material-ui/core/Box';
+import {Warning} from "@material-ui/icons";
 
 interface Props {
   onAdd: () => void;
@@ -99,10 +100,9 @@ export const AddDevice = observer(class AddDevice extends React.Component<Props>
       this.configFile = configFile;
       this.dialogOpen = true;
       this.reset();
-    } catch (error) {
+    } catch (error: any) {
       console.log(error);
-      // TODO: unwrap grpc error message
-      this.error = 'failed to add device';
+      this.error = 'Failed to add device: ' + error.message;
     }
   };
 
@@ -177,7 +177,12 @@ export const AddDevice = observer(class AddDevice extends React.Component<Props>
                   </AccordionDetails>
                 </Accordion>
               </Box>
-              <FormHelperText id="device-error-text" error={true}>{this.error}</FormHelperText>
+                { this.error &&
+                    <FormHelperText id="device-error-text" error={true}>
+                        <Warning/>
+                        <span>{this.error}</span>
+                    </FormHelperText>
+                }
               <Typography component="div" align="right">
                 <Button color="secondary" type="button" onClick={this.reset}>
                   Cancel

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -37,3 +37,16 @@ code {
 td.MuiTableCell-root, th.MuiTableCell-root {
   padding: 8px;
 }
+
+/* Improves readability of error message in 'add device' dialog. */
+.MuiFormHelperText-root.Mui-error {
+    margin-top: 8px;
+    margin-bottom: 8px;
+    font-size: 100%;
+}
+
+.MuiFormHelperText-root.Mui-error svg {
+  position: relative;
+  top: 0.25em;
+  margin-right: 8px;
+}


### PR DESCRIPTION
Currently, any error message of the 'add device' dialog only reads:

> failed to add device

This change improves the message by:
- appending the actual cause, and by
- increasing the size and adding a warning icon.

![2023-03-21_08-37](https://user-images.githubusercontent.com/3245637/226544031-4b1a1a41-9a7c-4382-b7f6-06502fa1d594.png)
